### PR TITLE
fix: underflow on total active stake

### DIFF
--- a/contracts/xalgo/consensus_state_v2.py
+++ b/contracts/xalgo/consensus_state_v2.py
@@ -13,9 +13,8 @@ class ConsensusV2GlobalState(EnumMeta):
     MAX_PROPOSER_BALANCE = Bytes("max_proposer_balance")
     FEE = Bytes("fee")  # 4 d.p
     PREMIUM = Bytes("premium")  # 16 d.p
+    LAST_PROPOSERS_ACTIVE_BALANCE = Bytes("last_proposers_active_balance")
     TOTAL_PENDING_STAKE = Bytes("total_pending_stake")
-    TOTAL_ACTIVE_STAKE = Bytes("total_active_stake")
-    TOTAL_REWARDS = Bytes("total_rewards")
     TOTAL_UNCLAIMED_FEES = Bytes("total_unclaimed_fees")
     CAN_IMMEDIATE_MINT = Bytes("can_immediate_mint")
     CAN_DELAY_MINT = Bytes("can_delay_mint")


### PR DESCRIPTION
### Describe the bug
There was a flaw in the internal tracking of `total_active_stake`. The global state variable is only increased by the amount of ALGO deposited however it is decreased by the amount of ALGO withdrawn. Since the amount of ALGO withdrawn includes both the original deposited amount and the rewards earned, the `total_active_stake` will eventually underflow. 

### Impact Details
Some ALGO is locked in the smart contract.

To simplify the bug:
- User A deposits 100 ALGO recieves 100 xALGO, `total_active_stake = 100 ALGO`
- After a year the user, accrues some rewards 10 ALGO so the xALGO they own is now worth 110 ALGO
- When the user will try to burn their 100 xALGO, it will fail because we will try to reduce `total_active_stake` (100 ALGO) by 110 ALGO which will underflow.

### Fix
The fix includes the following changes:
- Removed the `total_active_stake` from the global state and replaced it with `last_proposers_active_balance` which is defined as the the total balance of the proposers (excluding their minimum balance) minus the total pending stake.
- Removed `total_rewards` from the global state
- Changed `update_total_rewards_and_unclaimed_fees` to `sync_proposers_active_balance_and_unclaimed_fees`
- Reorded some of the updates